### PR TITLE
Reconcile schema drift with proper migration

### DIFF
--- a/apps/platform/prisma/migrations/20260415164226_reconcile_schema_drift/migration.sql
+++ b/apps/platform/prisma/migrations/20260415164226_reconcile_schema_drift/migration.sql
@@ -1,0 +1,13 @@
+-- Reconciles schema drift: these columns were added to schema.prisma without a migration.
+-- Production already has these columns (verified 2026-04-15); on prod, run:
+--   npx prisma migrate resolve --applied 20260415164226_reconcile_schema_drift
+
+-- AlterTable
+ALTER TABLE "Entry" ADD COLUMN "totalPositionsGained" INTEGER NOT NULL DEFAULT 0;
+
+-- AlterTable
+ALTER TABLE "RawResultUpload" ADD COLUMN "sessionLabel" TEXT;
+
+-- AlterTable
+ALTER TABLE "Venue" ADD COLUMN "appleMapsUrl" TEXT,
+ADD COLUMN "googleMapsUrl" TEXT;


### PR DESCRIPTION
## Summary
- Adds a proper migration for four columns that exist in `schema.prisma` and prod but were missing from `prisma/migrations/`: `Entry.totalPositionsGained`, `RawResultUpload.sessionLabel`, `Venue.googleMapsUrl`, `Venue.appleMapsUrl`
- Prod state verified 2026-04-15: all four columns already exist
- Unblocks contributors whose `prisma migrate dev` keeps regenerating an unwanted `_test` migration (see PR #74)

## Required deploy step

**Before merging** — on the prod database, mark this migration as already-applied so Prisma doesn't try to re-run the `ALTER TABLE` statements (which would fail since the columns exist):

```bash
DATABASE_URL="<prod-url>" npx prisma migrate resolve --applied 20260415164226_reconcile_schema_drift
```

After that, merge → Vercel's `prisma migrate deploy` will see no pending migrations.

## Test plan
- [ ] Run the `migrate resolve` command on prod
- [ ] Verify `_prisma_migrations` table on prod has the new migration row with `finished_at` set
- [ ] Merge PR
- [ ] Confirm Vercel deploy succeeds
- [ ] Have Arav rebase PR #74 and confirm `_test` migration no longer regenerates

🤖 Generated with [Claude Code](https://claude.com/claude-code)